### PR TITLE
Prefer dd/mm/yyyy over mm/dd/yyyy

### DIFF
--- a/parseTime.js
+++ b/parseTime.js
@@ -202,25 +202,6 @@ var parseTimeObject = {
       }
     }
   }
-  dateO.parsed = new Date();
-  dateO.parsed = new Date(Date.parse(string.replace(/((\d{1,2})(th |rd |ter ))/, "$2 ", "gm")));
-  if (!isNaN(dateO.parsed)) {
-    if (string.indexOf(dateO.parsed.getFullYear()) === -1) {
-      dateO.now = new Date();
-      dateO.now = Date.parse(now);
-      if (!isNaN(dateO.now)) {
-        dateO.parsed.setFullYear(dateO.now.getFullYear());
-        dateO.parsed.setTime(dateO.parsed.getTime() + 86400000);
-      }
-    }
-    dateO.parsed = dateO.parsed.getTime();
-    return {
-      'absolute': dateO.parsed,
-      'relative': (dateO.parsed - now),
-      'mode': 'absolute',
-      'pb': 2
-    };
-  }
 
   for (lang in parseTimeObject.words) {
     if (clockwords !== '') {
@@ -451,14 +432,18 @@ var parseTimeObject = {
       }
     }
   }
-  ddmmyyyy.match = /(\d\d?)[,\.](\d\d?)[,\.](\d\d(\d\d)?)/.exec(string);
+  ddmmyyyy.match = /(\d\d?)[,\/\-\.](\d\d?)[,\/\-\.](\d\d(\d\d)?)/.exec(string);
   if (ddmmyyyy.match !== null) {
     ddmmyyyy.day = ddmmyyyy.match[1];
     ddmmyyyy.month = ddmmyyyy.match[2];
     ddmmyyyy.year = ddmmyyyy.match[3];
+    if (ddmmyyyy.month < 1 || ddmmyyyy.month > 12) {
+        ddmmyyyy.day = ddmmyyyy.match[2];
+        ddmmyyyy.month = ddmmyyyy.match[1];
+    }
     pbint = 10;
   } else {
-    ddmmyyyy.match = /(\d\d(\d\d)?)[\/\-](\d\d?)[\/\-](\d\d?)/.exec(string);
+    ddmmyyyy.match = /(\d\d(\d\d)?)[,\/\-\.](\d\d?)[,\/\-\.](\d\d?)/.exec(string);
     if (ddmmyyyy.match !== null) {
       ddmmyyyy.day = ddmmyyyy.match[4];
       ddmmyyyy.month = ddmmyyyy.match[3];
@@ -479,6 +464,26 @@ var parseTimeObject = {
       'relative': dateO.parsed - now,
       'mode': 'absolute',
       'pb': pbint
+    };
+  }
+
+  // Last resort fallback to JS Date.parse()
+  dateO.parsed = new Date(Date.parse(string.replace(/((\d{1,2})(th |rd |ter ))/, "$2 ", "gm")));
+  if (!isNaN(dateO.parsed)) {
+    if (string.indexOf(dateO.parsed.getFullYear()) === -1) {
+      dateO.now = new Date();
+      dateO.now = Date.parse(now);
+      if (!isNaN(dateO.now)) {
+        dateO.parsed.setFullYear(dateO.now.getFullYear());
+        dateO.parsed.setTime(dateO.parsed.getTime() + 86400000);
+      }
+    }
+    dateO.parsed = dateO.parsed.getTime();
+    return {
+      'absolute': dateO.parsed,
+      'relative': (dateO.parsed - now),
+      'mode': 'absolute',
+      'pb': 2
     };
   }
 


### PR DESCRIPTION
Proposed fix for issue #24 _Prioritise dd/mm/yy over mm/dd/yy_

Dates of format xx/xx/xxxx and similar were picked up by the Date.parse() section in the beginning which defaults to mm/dd/yyyy format. I have moved this check all the to the end to attempt this only when all other rules fail.

The xx/xx/yyyy format rule already interprets as dd/mm/yyyy. A check has been added so that in case month is invalid it is interpreted as mm/dd/yyyy instead.

Finally, I've also unified the allowed set of separators for both of the date rules for consistency.

